### PR TITLE
Add -F option

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -67,6 +67,10 @@ struct Opt {
     #[structopt(long = "root")]
     root: bool,
 
+    /// Sampling frequency
+    #[structopt(short = "F", long = "freq")]
+    frequency: Option<u32>,
+
     trailing_arguments: Vec<String>,
 }
 
@@ -297,5 +301,6 @@ fn main() {
         Workload::Command(workload),
         &flamegraph_filename,
         opt.root,
+        opt.frequency,
     );
 }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -25,6 +25,10 @@ struct Opt {
     #[structopt(short = "p", long = "pid")]
     pid: Option<u32>,
 
+    /// Sampling frequency
+    #[structopt(short = "F", long = "freq")]
+    frequency: Option<u32>,
+
     trailing_arguments: Vec<String>,
 }
 
@@ -65,5 +69,6 @@ fn main() {
         workload,
         flamegraph_filename,
         opt.root,
+        opt.frequency,
     );
 }


### PR DESCRIPTION
Adds -F/--freq option to cli that allows passing sampling rate to profiler.
On Linux it changes value of -F option to perf record from default 99.
On Non-Linux OSes it changes the default value off 997 passed to dtrace script.

I haven't tested these change. I only know it compiles on Linux.

Fixes #21 