### PR TITLE
Fix building on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin/flamegraph.rs"
 
 [dependencies]
 inferno = "0.4"
-signal-hook = "0.1.8"
 structopt = "0.2.14"
 cargo_metadata = "0.7.1"
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use inferno::{
     },
 };
 
+#[cfg(unix)]
 use signal_hook;
 
 #[cfg(target_os = "linux")]
@@ -131,7 +132,7 @@ fn terminated_by_error(status: ExitStatus) -> bool {
 
 #[cfg(not(unix))]
 fn terminated_by_error(status: ExitStatus) -> bool {
-    !exit_status.success()
+    !status.success()
 }
 
 pub fn generate_flamegraph_by_running_command<
@@ -146,6 +147,7 @@ pub fn generate_flamegraph_by_running_command<
     // generate our flamegraph.  (ctrl+c will send the
     // SIGINT signal to all processes in the foreground
     // process group).
+    #[cfg(unix)]
     let handler = unsafe {
         signal_hook::register(signal_hook::SIGINT, || { })
             .expect("cannot register signal handler")
@@ -159,6 +161,7 @@ pub fn generate_flamegraph_by_running_command<
     let exit_status =
         recorder.wait().expect(arch::WAIT_ERROR);
 
+    #[cfg(unix)]
     signal_hook::unregister(handler);
 
     // only stop if perf exited unsuccessfully, but


### PR DESCRIPTION
Prior to this commit, it was not possible to build on Windows because of signal_hook. This commit changes the way signal_hook is used to only be imported when on Unix-like systems.

Additionally, during [`49b1ad`](
https://github.com/ferrous-systems/flamegraph/commit/49b1ad87cfaab97fe39e6ba5b3fb199241cd74c7#diff-b4aea3e418ccdb71239b96952d9cddb6R132) a variable was mistakenly left unchanged for the Windows variant of a function, which caused the build to fail.

This commit should resolve https://github.com/ferrous-systems/flamegraph/issues/49.

I've no idea what signal_hook is being used for here; please let me know if removing it from Windows would remove the functionality of the program as well.