### PR TITLE
Fix mangling of whitespace-bearing arguments

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -206,7 +206,7 @@ fn find_binary(ty: &str, path: &Path, bin: &str) -> String {
         })
 }
 
-fn workload(opt: &Opt) -> String {
+fn workload(opt: &Opt) -> Vec<String> {
     let mut metadata_cmd =
         cargo_metadata::MetadataCommand::new();
     metadata_cmd.no_deps();
@@ -268,11 +268,9 @@ fn workload(opt: &Opt) -> String {
 
     binary_path.push(target);
 
-    format!(
-        "{} {}",
-        binary_path.to_string_lossy(),
-        opt.trailing_arguments.join(" ")
-    )
+    let mut result = opt.trailing_arguments.clone();
+    result.insert(0, binary_path.to_string_lossy().into());
+    result
 }
 
 fn main() {

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -22,13 +22,13 @@ struct Opt {
     trailing_arguments: Vec<String>,
 }
 
-fn workload(opt: &Opt) -> String {
+fn workload(opt: &Opt) -> Vec<String> {
     if opt.trailing_arguments.is_empty() {
         eprintln!("no workload given to generate a flamegraph for!");
         std::process::exit(1);
     }
 
-    opt.trailing_arguments.join(" ")
+    opt.trailing_arguments.clone()
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod arch {
          child command to exit";
 
     pub(crate) fn initial_command(
-        workload: String,
+        workload: Vec<String>,
         sudo: bool,
     ) -> Command {
         let mut command = if sudo {
@@ -54,9 +54,7 @@ mod arch {
             command.arg(arg);
         }
 
-        for item in workload.split_whitespace() {
-            command.arg(item);
-        }
+        command.args(&workload);
 
         command
     }
@@ -81,7 +79,7 @@ mod arch {
          child command to exit";
 
     pub(crate) fn initial_command(
-        workload: String,
+        workload: Vec<String>,
         sudo: bool,
     ) -> Command {
         let mut command = if sudo {
@@ -105,7 +103,7 @@ mod arch {
         command.arg("cargo-flamegraph.stacks");
 
         command.arg("-c");
-        command.arg(&workload);
+        command.args(&workload);
 
         command
     }
@@ -151,7 +149,7 @@ fn terminated_by_error(status: ExitStatus) -> bool {
 pub fn generate_flamegraph_by_running_command<
     P: AsRef<std::path::Path>,
 >(
-    workload: String,
+    workload: Vec<String>,
     flamegraph_filename: P,
     sudo: bool,
 ) {


### PR DESCRIPTION
Comes up when e.g. trying to filter a Criterion benchmark binary that uses human-friendly benchmark names.