### PR TITLE
Profile by pid

### DIFF
--- a/src/bin/cargo-flamegraph.rs
+++ b/src/bin/cargo-flamegraph.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 
 use structopt::StructOpt;
 
+use flamegraph::Workload;
+
 #[derive(Debug, StructOpt)]
 #[structopt(raw(
     setting = "structopt::clap::AppSettings::TrailingVarArg"
@@ -285,8 +287,8 @@ fn main() {
         .take()
         .unwrap_or("flamegraph.svg".into());
 
-    flamegraph::generate_flamegraph_by_running_command(
-        workload,
+    flamegraph::generate_flamegraph_for_workload(
+        Workload::Command(workload),
         &flamegraph_filename,
         opt.root,
     );

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -21,16 +21,30 @@ struct Opt {
     #[structopt(long = "root")]
     root: bool,
 
+    /// Profile a running process by pid
+    #[structopt(
+        short = "p",
+        long = "pid"
+    )]
+    pid: Option<u32>,
+
     trailing_arguments: Vec<String>,
 }
 
 fn workload(opt: &Opt) -> Workload {
-    if opt.trailing_arguments.is_empty() {
-        eprintln!("no workload given to generate a flamegraph for!");
-        std::process::exit(1);
-    }
+    match opt.pid {
+        Some(p) => {
+            Workload::Pid(p)
+        },
+        None => {
+            if opt.trailing_arguments.is_empty() {
+                eprintln!("no workload given to generate a flamegraph for!");
+                std::process::exit(1);
+            }
 
-    Workload::Command(opt.trailing_arguments.clone())
+            Workload::Command(opt.trailing_arguments.clone())
+        }
+    }
 }
 
 fn main() {

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
+use flamegraph::Workload;
+
 #[derive(Debug, StructOpt)]
 #[structopt(raw(
     setting = "structopt::clap::AppSettings::TrailingVarArg"
@@ -22,13 +24,13 @@ struct Opt {
     trailing_arguments: Vec<String>,
 }
 
-fn workload(opt: &Opt) -> Vec<String> {
+fn workload(opt: &Opt) -> Workload {
     if opt.trailing_arguments.is_empty() {
         eprintln!("no workload given to generate a flamegraph for!");
         std::process::exit(1);
     }
 
-    opt.trailing_arguments.clone()
+    Workload::Command(opt.trailing_arguments.clone())
 }
 
 fn main() {
@@ -41,7 +43,7 @@ fn main() {
         .take()
         .unwrap_or("flamegraph.svg".into());
 
-    flamegraph::generate_flamegraph_by_running_command(
+    flamegraph::generate_flamegraph_for_workload(
         workload,
         flamegraph_filename,
         opt.root,

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -34,6 +34,11 @@ struct Opt {
 fn workload(opt: &Opt) -> Workload {
     match opt.pid {
         Some(p) => {
+            if !opt.trailing_arguments.is_empty() {
+                eprintln!("only a pid or command can be specified!");
+                std::process::exit(1);
+            }
+
             Workload::Pid(p)
         },
         None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ mod arch {
         match workload {
             Workload::Command(c) => {
                 command.arg("-c");
-                command.args(&workload);
+                command.args(&c);
             },
             Workload::Pid(p) => {
                 command.arg("-p");


### PR DESCRIPTION
Sometimes it is preferable to be able to profile a running process instead of needing to restart the process under the profiler. This PR adds a `Workload` enum which can contain a command or a pid. Additionally a flag for passing in a pid instead of a command is provided for the `flamegraph` binary.

Usage:
```
flamegraph -p 2147
```

These changes do not break the existing cli interface.